### PR TITLE
change sendLogToClient to accept string instead of char*

### DIFF
--- a/src/ofxRemoteUIServer.cpp
+++ b/src/ofxRemoteUIServer.cpp
@@ -1421,17 +1421,12 @@ void ofxRemoteUIServer::connect(string ipAddress, int port){
 	readyToSend = true;
 }
 
-void ofxRemoteUIServer::sendLogToClient(char* format, ...){
+void ofxRemoteUIServer::sendLogToClient(string message){
 
 	if(readyToSend){
-		char line[1024]; //this will crash (or worse, make a memory mess) if you try to log >= 1024 chars
-		va_list args;
-		va_start(args, format);
-		vsprintf(line, format,  args);
-
 		ofxOscMessage m;
 		m.setAddress("LOG_");
-		m.addStringArg(string(line));
+		m.addStringArg(message);
 		try{
 			oscSender.sendMessage(m);
 		}catch(exception e){

--- a/src/ofxRemoteUIServer.h
+++ b/src/ofxRemoteUIServer.h
@@ -219,7 +219,7 @@ public:
 	void setDrawsNotificationsAutomaticallly(bool draw);
 	void setNetworkInterface(string iface);
 	void pushParamsToClient(); //pushes all param values to client, updating its UI
-	void sendLogToClient(char* format, ...);
+	void sendLogToClient(string message);
 	void setClearXMLonSave(bool clear){clearXmlOnSaving = clear;}
 
 	void removeParamFromDB(string paramName);	//useful for params its value is kinda set,


### PR DESCRIPTION
string literal to char\* is being deprecated (Xcode warns us), and it's easy enough for the user to format a string to pass themselves. The char\* type makes it particularly difficult to pass a string constructed with a stringstream.

This may make it slightly less convenient to pass formatted strings, but more generally convenient.
