### PR TITLE
overload sendLogToClient with string version

### DIFF
--- a/src/ofxRemoteUIServer.h
+++ b/src/ofxRemoteUIServer.h
@@ -219,7 +219,8 @@ public:
 	void setDrawsNotificationsAutomaticallly(bool draw);
 	void setNetworkInterface(string iface);
 	void pushParamsToClient(); //pushes all param values to client, updating its UI
-	void sendLogToClient(char* format, ...);
+	void sendLogToClient(const char* format, ...);
+	void sendLogToClient(string message);
 	void setClearXMLonSave(bool clear){clearXmlOnSaving = clear;}
 
 	void removeParamFromDB(string paramName);	//useful for params its value is kinda set,


### PR DESCRIPTION
add a version of sendLogToClient that simply accepts a string.
The char\* / format version calls this new method once formatted to a string.
It also now accepts const char*, avoiding deprecation warnings
Adds protection against format args >= 1024
